### PR TITLE
[docs] CSS overflow scroll fix for desktop view.

### DIFF
--- a/site/less/article.less
+++ b/site/less/article.less
@@ -1,5 +1,6 @@
 body > main > article {
-  overflow: scroll;
+  overflow-x: auto;
+  overflow-y: scroll;
   padding-bottom: 4rem;
   ul {
     padding-inline-start: 2rem;

--- a/site/less/layout.less
+++ b/site/less/layout.less
@@ -36,7 +36,7 @@ body {
     > nav {
       display: none;
       width: 16rem;
-      overflow: scroll;
+      overflow: auto;
       margin-left: 1rem;
     }
     > article {
@@ -44,7 +44,7 @@ body {
       padding: 0 1rem;
       min-width: 100vw;
       max-width: 50rem;
-      overflow: scroll;
+      overflow: auto;
       &#home {
         max-width: 84rem;
       }
@@ -52,7 +52,7 @@ body {
     > aside {
       display: none;
       width: 16rem;
-      overflow: scroll;
+      overflow: auto;
       margin-right: 1rem;
     }
   }


### PR DESCRIPTION
## Summary

On desktop view of the homepage(index), the scroll bar for the horizontal view is fixed even though no content is overflowing. This is also the case when viewing the Api, Demos and Guides. 

Changing the overflow value to 'auto' improves the overall presentation(layout.less). That is, if the content does overflow along the x and y axis, then scroll bars will be shown.

On the main index page(article.less), I included both overflow-x and overflow-y properties to retain the original y axis behavior of forcing the scroll.

## How did you test this change?

Using firefox and chrome browsers on desktop view. No presentational issues were present on mobile view, no changes were made to responsive views.
