### PR TITLE
chore: tiny documentation correction

### DIFF
--- a/site/guides/03_schemas_and_persistence/5_custom_persistence.md
+++ b/site/guides/03_schemas_and_persistence/5_custom_persistence.md
@@ -23,8 +23,8 @@ To build a custom Persister, you should provide four functions:
   was returned from your `addPersisterListener` implementation.
   @returns A reference to the new Persister object.
 
-Note that the first two functions are synchronous and must return promises. The
-latter two are synchronous and should return `void`.
+Note that the first two functions are asynchronous and _must_ return promises. The
+latter two are synchronous and should return `void` (i.e. should not return a value at all).
 
 This API changed in v4.0. Any custom persisters created on previous versions
 should be upgraded. Most notably, the `setPersisted` function parameter is


### PR DESCRIPTION
## Summary

I'm going to be honest, I was just reading the documentation and thought to myself "That should say asynchronous..." and because I am procrastinating the things I should be doing, I made a PR.

## How did you test this change?

I did not, as it was a documentation change. I fully understand if this get's closed without comment. 🙂 
