### PR TITLE
Fix broken Discord link in 09_faq.md

### DIFF
--- a/site/guides/09_faq.md
+++ b/site/guides/09_faq.md
@@ -52,6 +52,5 @@ Please see the [demos](/demos/) for ideas!
 ## What If I Have Other Questions?
 
 Please open a pull request or issue on GitHub and ask! Or ping the project on
-[Twitter](https://twitter.com/tinybasejs), <a
-href='https://discord.com/invite/mGz3mevwP8'>Discord</a>, or
+[Twitter](https://twitter.com/tinybasejs), [Discord](https://discord.com/invite/mGz3mevwP8), or
 [Facebook](https://facebook.com/tinybasejs).


### PR DESCRIPTION
## Summary

On https://tinybase.org/guides/faq/, the Discord link shows up as unescaped html ¯\\_(ツ)_/¯

## How did you test this change?

Visual inspection (i.e. I did not test the change).