### PR TITLE
Closes #116 IndexedDB integration for service workers

### DIFF
--- a/src/persisters/persister-indexed-db.ts
+++ b/src/persisters/persister-indexed-db.ts
@@ -58,12 +58,10 @@ export const createIndexedDbPersister = ((
     create: 0 | 1 = 0,
   ): Promise<[any, any]> =>
     promiseNew((resolve, reject) => {
-      let request: IDBOpenDBRequest;
-      if (WINDOW) {
-        request = WINDOW.indexedDB.open(dbName, create ? 2 : undefined);
-      } else {
-        request = indexedDB.open(dbName, create ? 2 : undefined);
-      }
+      const request = (WINDOW ? WINDOW.indexedDB : indexedDB).open(
+        dbName,
+        create ? 2 : undefined,
+      );
       request.onupgradeneeded = () =>
         create &&
         arrayMap(OBJECT_STORE_NAMES, (objectStoreName) => {

--- a/src/persisters/persister-indexed-db.ts
+++ b/src/persisters/persister-indexed-db.ts
@@ -58,7 +58,12 @@ export const createIndexedDbPersister = ((
     create: 0 | 1 = 0,
   ): Promise<[any, any]> =>
     promiseNew((resolve, reject) => {
-      const request = WINDOW.indexedDB.open(dbName, create ? 2 : undefined);
+      let request: IDBOpenDBRequest;
+      if (WINDOW) {
+        request = WINDOW.indexedDB.open(dbName, create ? 2 : undefined);
+      } else {
+        request = indexedDB.open(dbName, create ? 2 : undefined);
+      }
       request.onupgradeneeded = () =>
         create &&
         arrayMap(OBJECT_STORE_NAMES, (objectStoreName) => {


### PR DESCRIPTION
## Summary

- Closes issue #116
- IndexedDB integration can now be used with service workers, such as in Chrome extensions' background.js files.

## How did you test this change?

Ran all the tests successfully and confirmed that the fix indeed works with my own Chrome extension.

## Side note:
Didn't add any new tests. After reviewing the codebase, I believe it may not be necessary to add them, but I'm not entirely sure of this. Further review or feedback might be helpful.
