### PR TITLE
Introduce withoutOnConflict flag to sqlite-persister, add type='view' to FROM_PRAGMA_TABLE statement

### DIFF
--- a/src/persisters/sqlite/create.ts
+++ b/src/persisters/sqlite/create.ts
@@ -30,6 +30,7 @@ export const createSqlitePersister = <UpdateListeningHandle>(
   onIgnoredError: ((error: any) => void) | undefined,
   db: any,
   getThing = 'getDb',
+  useOnConflict?: boolean,
 ): Persister => {
   let dataVersion: number | null;
   let schemaVersion: number | null;
@@ -102,5 +103,6 @@ export const createSqlitePersister = <UpdateListeningHandle>(
     collValues(managedTableNamesSet),
     db,
     getThing,
+    useOnConflict,
   );
 };

--- a/src/persisters/sqlite/tabular.ts
+++ b/src/persisters/sqlite/tabular.ts
@@ -31,9 +31,10 @@ export const createTabularSqlitePersister = <ListeningHandle>(
   managedTableNames: string[],
   db: any,
   getThing: string,
+  useOnConflict?: boolean,
 ): Persister => {
   const [refreshSchema, loadTable, saveTable, transaction] =
-    getCommandFunctions(cmd, managedTableNames, onIgnoredError);
+    getCommandFunctions(cmd, managedTableNames, onIgnoredError, useOnConflict);
 
   const saveTables = async (
     tables:

--- a/test/unit/persisters/persister-sqlite-tabular.test.ts
+++ b/test/unit/persisters/persister-sqlite-tabular.test.ts
@@ -856,7 +856,7 @@ describe.each(Object.entries(VARIANTS))(
         expect(sqlLogs).toEqual([
           ['BEGIN', undefined],
           [
-            `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+            `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
             ['tinybase_values', 't1', 't2', 't3'],
           ],
           [
@@ -916,7 +916,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -954,7 +954,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -991,7 +991,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1028,7 +1028,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1069,7 +1069,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1107,7 +1107,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1144,7 +1144,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1186,7 +1186,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1224,7 +1224,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1258,7 +1258,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1300,7 +1300,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1341,7 +1341,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1379,7 +1379,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],
@@ -1410,7 +1410,7 @@ describe.each(Object.entries(VARIANTS))(
           expect(sqlLogs).toEqual([
             ['BEGIN', undefined],
             [
-              `SELECT name FROM pragma_table_list WHERE schema='main'AND type='table'AND name IN(?,?,?,?)ORDER BY name`,
+              `SELECT name FROM pragma_table_list WHERE schema='main'AND(type='table'OR type='view')AND name IN(?,?,?,?)ORDER BY name`,
               ['tinybase_values', 't1', 't2', 't3'],
             ],
             ['SELECT name,type FROM pragma_table_info(?)', ['t1']],


### PR DESCRIPTION
## Summary

This is the first PR in pursuit of #130. I decided to split up the work in the 1) prerequisites (introducing the ability to read VIEWS and the option to write changes using INSERT OR REPLACE instead of using ON CONFLICT) and 2) the actual PowerSync persister to make this easier to digest. The whole PowerSync adapter is implemented in my fork: https://github.com/bndkt/tinybase/tree/powersync

## How did you test this change?

I made sure all existing tests still succeed. I had to adapt the tests that compare expected to actual SQL statements though, as this change changes some SQL statements (adding views).
