### PR TITLE
convert getNewRowId from recursive to iterative

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -519,11 +519,11 @@ export const createStore: typeof createStoreDecl = (): Store => {
 
   const getNewRowId = (tableId: Id, reuse: 0 | 1): Id => {
     const [getId] = mapGet(tablePoolFunctions, tableId) as PoolFunctions;
-    const rowId = getId(reuse);
-    if (!collHas(mapGet(tablesMap, tableId), rowId)) {
-      return rowId;
-    }
-    return getNewRowId(tableId, reuse);
+    let rowId;
+    do {
+      rowId = getId(reuse);
+    } while (collHas(mapGet(tablesMap, tableId), rowId));
+    return rowId;
   };
 
   const getOrCreateTable = (tableId: Id) =>


### PR DESCRIPTION
Doing so avoids `Maximum call stack size exceeded` in tables with many rows

## Summary

resolves #192 

## How did you test this change?

Patched `tinybase` locally while using it as a dependency in my own project to confirm that converting to a `while` loop avoids the `Maximum call stack size exceeded` exception.
