### PR TITLE
Implement #233: add where condition to tabular persister

### DIFF
--- a/src/@types/persisters/docs.js
+++ b/src/@types/persisters/docs.js
@@ -497,7 +497,8 @@
  * |-|-|-|
  * |`tableId`|Id|The Id of the Store Table into which data from this database table should be loaded.|
  * |`rowIdColumnName?`|string|The optional name of the column in the database table that will be used as the Row Ids in the Store Table, defaulting to '_id'.|
- *
+ * |`whereCondition?`|string|The optional SQL WHERE clause that will be used to filter the rows that are loaded into the Store Table.
+ * 
  * As a shortcut, if you do not need to specify a custom `rowIdColumnName`, you
  * can simply provide the Id of the Store Table instead of the whole object.
  *
@@ -585,6 +586,13 @@
          * @since v4.0.0
          */
         /// DpcTabularLoad.rowIdColumnName
+        /**
+         * The optional SQL WHERE clause that will be used to filter the rows
+         * that are loaded into the Store Table.
+         * @category Configuration
+         * @since v6.1.0
+         */
+        /// DpcTabularLoad.whereCondition
       }
     }
   }
@@ -603,6 +611,7 @@
  * |`rowIdColumnName?`|string|The optional name of the column in the database table that will be used to save the Row Ids from the Store Table, defaulting to '_id'.|
  * |`deleteEmptyColumns?`|boolean|Whether columns in the database table will be removed if they are empty in the Store Table, defaulting to false.|
  * |`deleteEmptyTable?`|boolean|Whether tables in the database will be removed if the Store Table is empty, defaulting to false.|
+ * |`whereCondition?`|string|The optional SQL WHERE clause that will be used to scope cleanup operations to the Store Table. Defaults to same as `DpcTabularLoad.whereCondition`.
  *
  * As a shortcut, if you do not need to specify a custom `rowIdColumnName`, or
  * enable the `deleteEmptyColumns` or `deleteEmptyTable` settings, you can
@@ -718,6 +727,13 @@
          * @since v4.0.0
          */
         /// DpcTabularSave.deleteEmptyTable
+        /**
+         * The optional SQL WHERE clause that will be used to scope cleanup operations
+         * to the Store Table. Defaults to same as `DpcTabularLoad.whereCondition`.
+         * @category Configuration
+         * @since v6.1.0
+         */
+        /// DpcTabularSave.whereCondition
       }
     }
   }

--- a/src/@types/persisters/docs.js
+++ b/src/@types/persisters/docs.js
@@ -498,6 +498,7 @@
  * |`tableId`|Id|The Id of the Store Table into which data from this database table should be loaded.|
  * |`rowIdColumnName?`|string|The optional name of the column in the database table that will be used as the Row Ids in the Store Table, defaulting to '_id'.|
  * |`whereCondition?`|string|The optional SQL WHERE clause that will be used to filter the rows that are loaded into the Store Table.
+ * |`whenCondition?`|string|Postgres only: Optional SQL WHEN clause that is used by trigger to sync changes from the database table to the Store Table.
  * 
  * As a shortcut, if you do not need to specify a custom `rowIdColumnName`, you
  * can simply provide the Id of the Store Table instead of the whole object.
@@ -593,6 +594,12 @@
          * @since v6.1.0
          */
         /// DpcTabularLoad.whereCondition
+        /**
+         * Postgres only: Optional SQL WHEN clause that is used by trigger to sync changes from the database table to the Store Table.
+         * @category Configuration
+         * @since v6.1.0
+         */
+        /// DpcTabularLoad.whenCondition
       }
     }
   }

--- a/src/@types/persisters/docs.js
+++ b/src/@types/persisters/docs.js
@@ -497,8 +497,7 @@
  * |-|-|-|
  * |`tableId`|Id|The Id of the Store Table into which data from this database table should be loaded.|
  * |`rowIdColumnName?`|string|The optional name of the column in the database table that will be used as the Row Ids in the Store Table, defaulting to '_id'.|
- * |`whereCondition?`|string|The optional SQL WHERE clause that will be used to filter the rows that are loaded into the Store Table.
- * |`whenCondition?`|string|Postgres only: Optional SQL WHEN clause that is used by trigger to sync changes from the database table to the Store Table.
+ * |`condition?`|string|The optional SQL WHERE clause that will be used to filter the rows that are loaded into the Store Table. When set it must include the `$tableName` placeholder for the table name.|
  * 
  * As a shortcut, if you do not need to specify a custom `rowIdColumnName`, you
  * can simply provide the Id of the Store Table instead of the whole object.
@@ -589,17 +588,12 @@
         /// DpcTabularLoad.rowIdColumnName
         /**
          * The optional SQL WHERE clause that will be used to filter the rows
-         * that are loaded into the Store Table.
+         * that are loaded into the Store Table. When set it must include the
+         * `$tableName` placeholder for the table name.
          * @category Configuration
          * @since v6.1.0
          */
-        /// DpcTabularLoad.whereCondition
-        /**
-         * Postgres only: Optional SQL WHEN clause that is used by trigger to sync changes from the database table to the Store Table.
-         * @category Configuration
-         * @since v6.1.0
-         */
-        /// DpcTabularLoad.whenCondition
+        /// DpcTabularLoad.condition
       }
     }
   }
@@ -618,7 +612,7 @@
  * |`rowIdColumnName?`|string|The optional name of the column in the database table that will be used to save the Row Ids from the Store Table, defaulting to '_id'.|
  * |`deleteEmptyColumns?`|boolean|Whether columns in the database table will be removed if they are empty in the Store Table, defaulting to false.|
  * |`deleteEmptyTable?`|boolean|Whether tables in the database will be removed if the Store Table is empty, defaulting to false.|
- * |`whereCondition?`|string|The optional SQL WHERE clause that will be used to scope cleanup operations to the Store Table. Defaults to same as `DpcTabularLoad.whereCondition`.
+ * |`condition?`|string|The optional SQL WHERE clause that will be used to scope cleanup operations to the Store Table. When set it must include the `$tableName` placeholder for the table name. Defaults to `DpcTabularLoad.condition`.|
  *
  * As a shortcut, if you do not need to specify a custom `rowIdColumnName`, or
  * enable the `deleteEmptyColumns` or `deleteEmptyTable` settings, you can
@@ -736,11 +730,12 @@
         /// DpcTabularSave.deleteEmptyTable
         /**
          * The optional SQL WHERE clause that will be used to scope cleanup operations
-         * to the Store Table. Defaults to same as `DpcTabularLoad.whereCondition`.
+         * to the Store Table. When set it must include the `$tableName` placeholder for
+         * the table name. Defaults to `DpcTabularLoad.condition`.
          * @category Configuration
          * @since v6.1.0
          */
-        /// DpcTabularSave.whereCondition
+        /// DpcTabularSave.condition
       }
     }
   }

--- a/src/@types/persisters/index.d.ts
+++ b/src/@types/persisters/index.d.ts
@@ -117,6 +117,8 @@ export type DpcTabularLoad = {
         rowIdColumnName?: string;
         /// DpcTabularLoad.whereCondition
         whereCondition?: string;
+        /// DpcTabularLoad.whenCondition
+        whenCondition?: string;
       }
     | Id;
 };

--- a/src/@types/persisters/index.d.ts
+++ b/src/@types/persisters/index.d.ts
@@ -115,10 +115,8 @@ export type DpcTabularLoad = {
         tableId: Id;
         /// DpcTabularLoad.rowIdColumnName
         rowIdColumnName?: string;
-        /// DpcTabularLoad.whereCondition
-        whereCondition?: string;
-        /// DpcTabularLoad.whenCondition
-        whenCondition?: string;
+        /// DpcTabularLoad.condition
+        condition?: `${string}$tableName${string}`;
       }
     | Id;
 };
@@ -135,8 +133,8 @@ export type DpcTabularSave = {
         deleteEmptyColumns?: boolean;
         /// DpcTabularSave.deleteEmptyTable
         deleteEmptyTable?: boolean;
-        /// DpcTabularLoad.whereCondition
-        whereCondition?: string;
+        /// DpcTabularLoad.condition
+        condition?: `${string}$tableName${string}`;
       }
     | string;
 };

--- a/src/@types/persisters/index.d.ts
+++ b/src/@types/persisters/index.d.ts
@@ -115,6 +115,8 @@ export type DpcTabularLoad = {
         tableId: Id;
         /// DpcTabularLoad.rowIdColumnName
         rowIdColumnName?: string;
+        /// DpcTabularLoad.whereCondition
+        whereCondition?: string;
       }
     | Id;
 };
@@ -131,6 +133,8 @@ export type DpcTabularSave = {
         deleteEmptyColumns?: boolean;
         /// DpcTabularSave.deleteEmptyTable
         deleteEmptyTable?: boolean;
+        /// DpcTabularLoad.whereCondition
+        whereCondition?: string;
       }
     | string;
 };

--- a/src/persisters/common/database/commands.ts
+++ b/src/persisters/common/database/commands.ts
@@ -239,8 +239,11 @@ export const getCommandFunctions = (
                 DELETE_FROM +
                   escapeId(tableName) +
                   WHERE +
+                  ' (' +
                   escapeId(rowIdColumnName) +
-                  '=$1',
+                  '=$1) AND (' +
+                  getWhereCondition(tableName, condition) +
+                  ')',
                 [rowId],
               );
             } else if (!arrayIsEmpty(settingColumnNames)) {
@@ -290,7 +293,7 @@ export const getCommandFunctions = (
             WHERE +
             escapeId(rowIdColumnName) +
             `NOT IN(${getPlaceholders(deleteRowIds)}) ` +
-            `AND${getWhereCondition(tableName, condition)}`,
+            `AND (${getWhereCondition(tableName, condition)})`,
           deleteRowIds,
         );
       } else if (collHas(schemaMap, tableName)) {

--- a/src/persisters/common/database/commands.ts
+++ b/src/persisters/common/database/commands.ts
@@ -56,7 +56,7 @@ export const getCommandFunctions = (
   loadTable: (
     tableName: string,
     rowIdColumnName: string,
-    whereCondition?: string | null,
+    condition?: `${string}$tableName${string}` | null,
   ) => Promise<Table>,
   saveTable: (
     tableName: string,
@@ -70,7 +70,7 @@ export const getCommandFunctions = (
       | undefined,
     deleteEmptyColumns: boolean,
     deleteEmptyTable: boolean,
-    whereCondition: string | null,
+    condition: `${string}$tableName${string}` | null,
     partial?: boolean,
   ) => Promise<void>,
   transaction: <Return>(actions: () => Promise<Return>) => Promise<Return>,
@@ -91,7 +91,7 @@ export const getCommandFunctions = (
   const loadTable = async (
     tableName: string,
     rowIdColumnName: string,
-    whereCondition: string | null = null,
+    condition: `${string}$tableName${string}` | null = null,
   ): Promise<Table> =>
     canSelect(tableName, rowIdColumnName)
       ? objNew(
@@ -101,7 +101,7 @@ export const getCommandFunctions = (
                 SELECT_STAR_FROM +
                   escapeId(tableName) +
                   WHERE +
-                  getWhereCondition(whereCondition),
+                  getWhereCondition(tableName, condition),
               ),
               (row) => [
                 row[rowIdColumnName],
@@ -127,7 +127,7 @@ export const getCommandFunctions = (
       | undefined,
     deleteEmptyColumns: boolean,
     deleteEmptyTable: boolean,
-    whereCondition: string | null = null,
+    condition: `${string}$tableName${string}` | null = null,
     partial = false,
   ): Promise<void> => {
     const settingColumnNameSet = setNew<string>();
@@ -142,7 +142,7 @@ export const getCommandFunctions = (
     if (
       !partial &&
       deleteEmptyTable &&
-      !whereCondition &&
+      !condition &&
       arrayIsEmpty(settingColumnNames) &&
       collHas(schemaMap, tableName)
     ) {
@@ -228,7 +228,7 @@ export const getCommandFunctions = (
           DELETE_FROM +
             escapeId(tableName) +
             WHERE +
-            getWhereCondition(whereCondition),
+            getWhereCondition(tableName, condition),
         );
       } else {
         await promiseAll(
@@ -290,7 +290,7 @@ export const getCommandFunctions = (
             WHERE +
             escapeId(rowIdColumnName) +
             `NOT IN(${getPlaceholders(deleteRowIds)}) ` +
-            `AND${getWhereCondition(whereCondition)}`,
+            `AND${getWhereCondition(tableName, condition)}`,
           deleteRowIds,
         );
       } else if (collHas(schemaMap, tableName)) {
@@ -299,7 +299,7 @@ export const getCommandFunctions = (
           DELETE_FROM +
             escapeId(tableName) +
             WHERE +
-            getWhereCondition(whereCondition),
+            getWhereCondition(tableName, condition),
         );
       }
     }

--- a/src/persisters/common/database/common.ts
+++ b/src/persisters/common/database/common.ts
@@ -52,3 +52,6 @@ export const getPlaceholders = (array: any[], offset = [1]) =>
     arrayMap(array, () => '$' + offset[0]++),
     COMMA,
   );
+
+export const getWhereCondition = (whereCondition: string | null) =>
+  whereCondition ? ' ' + whereCondition : ' true';

--- a/src/persisters/common/database/common.ts
+++ b/src/persisters/common/database/common.ts
@@ -30,6 +30,7 @@ export const DATA_VERSION = 'data_version';
 export const SCHEMA_VERSION = 'schema_version';
 export const FROM = 'FROM ';
 export const PRAGMA_TABLE = 'pragma_table_';
+export const TABLE_NAME_PLACEHOLDER = '$tableName';
 
 export const getWrappedCommand = (
   executeCommand: DatabaseExecuteCommand,
@@ -53,5 +54,7 @@ export const getPlaceholders = (array: any[], offset = [1]) =>
     COMMA,
   );
 
-export const getWhereCondition = (whereCondition: string | null) =>
-  whereCondition ? ' ' + whereCondition : ' true';
+export const getWhereCondition = (tableName: string, condition?: string | null) =>
+  condition
+    ? ' ' + condition.replace(TABLE_NAME_PLACEHOLDER, escapeId(tableName))
+    : ' true';

--- a/src/persisters/common/database/config.ts
+++ b/src/persisters/common/database/config.ts
@@ -24,8 +24,7 @@ export type DefaultedTabularConfig = [
     [
       tableId: Id,
       rowIdColumnName: string,
-      whereCondition: string | null,
-      whenCondition: string | null,
+      condition: `${string}$tableName${string}` | null,
     ]
   >,
   tablesSaveConfig: IdMap<
@@ -34,7 +33,7 @@ export type DefaultedTabularConfig = [
       rowIdColumnName: string,
       deleteEmptyColumns: boolean,
       deleteEmptyTable: boolean,
-      whereCondition: string | null,
+      condition: `${string}$tableName${string}` | null,
     ]
   >,
   valuesConfig: [load: boolean, save: boolean, tableName: string],
@@ -55,8 +54,7 @@ const TABLE_ID = 'tableId';
 const TABLE_NAME = 'tableName';
 const DELETE_EMPTY_COLUMNS = 'deleteEmptyColumns';
 const DELETE_EMPTY_TABLE = 'deleteEmptyTable';
-const WHERE_CONDITION = 'whereCondition';
-const WHEN_CONDITION = 'whenCondition';
+const CONDITION = 'condition';
 const DEFAULT_CONFIG: DatabasePersisterConfig = {
   mode: JSON,
   [AUTO_LOAD_INTERVAL_SECONDS]: 1,
@@ -150,8 +148,7 @@ export const getConfigStructures = (
       {
         [TABLE_ID]: null,
         [ROW_ID_COLUMN_NAME]: DEFAULT_ROW_ID_COLUMN_NAME,
-        [WHERE_CONDITION]: null,
-        [WHEN_CONDITION]: null,
+        [CONDITION]: null,
       },
       TABLE_ID,
       (tableName) => collHas(excludedTableNames, tableName),
@@ -164,7 +161,7 @@ export const getConfigStructures = (
         [ROW_ID_COLUMN_NAME]: DEFAULT_ROW_ID_COLUMN_NAME,
         [DELETE_EMPTY_COLUMNS]: 0,
         [DELETE_EMPTY_TABLE]: 0,
-        [WHERE_CONDITION]: load[WHERE_CONDITION] ?? null,
+        [CONDITION]: load[CONDITION] ?? null,
       },
       TABLE_NAME,
       (_, tableName) => collHas(excludedTableNames, tableName),

--- a/src/persisters/common/database/config.ts
+++ b/src/persisters/common/database/config.ts
@@ -20,13 +20,16 @@ export type DefaultedJsonConfig = [
   storeColumnName: string,
 ];
 export type DefaultedTabularConfig = [
-  tablesLoadConfig: IdMap<[tableId: Id, rowIdColumnName: string]>,
+  tablesLoadConfig: IdMap<
+    [tableId: Id, rowIdColumnName: string, whereCondition: string | null]
+  >,
   tablesSaveConfig: IdMap<
     [
       tableName: string,
       rowIdColumnName: string,
       deleteEmptyColumns: boolean,
       deleteEmptyTable: boolean,
+      whereCondition: string | null,
     ]
   >,
   valuesConfig: [load: boolean, save: boolean, tableName: string],
@@ -47,6 +50,7 @@ const TABLE_ID = 'tableId';
 const TABLE_NAME = 'tableName';
 const DELETE_EMPTY_COLUMNS = 'deleteEmptyColumns';
 const DELETE_EMPTY_TABLE = 'deleteEmptyTable';
+const WHERE_CONDITION = 'whereCondition';
 
 const DEFAULT_CONFIG: DatabasePersisterConfig = {
   mode: JSON,
@@ -138,7 +142,11 @@ export const getConfigStructures = (
   const tabularConfig = [
     getDefaultedTabularConfigMap(
       load,
-      {[TABLE_ID]: null, [ROW_ID_COLUMN_NAME]: DEFAULT_ROW_ID_COLUMN_NAME},
+      {
+        [TABLE_ID]: null,
+        [ROW_ID_COLUMN_NAME]: DEFAULT_ROW_ID_COLUMN_NAME,
+        [WHERE_CONDITION]: null,
+      },
       TABLE_ID,
       (tableName) => collHas(excludedTableNames, tableName),
       (tableName) => setAdd(managedTableNames, tableName),
@@ -150,6 +158,7 @@ export const getConfigStructures = (
         [ROW_ID_COLUMN_NAME]: DEFAULT_ROW_ID_COLUMN_NAME,
         [DELETE_EMPTY_COLUMNS]: 0,
         [DELETE_EMPTY_TABLE]: 0,
+        [WHERE_CONDITION]: load[WHERE_CONDITION] ?? null,
       },
       TABLE_NAME,
       (_, tableName) => collHas(excludedTableNames, tableName),

--- a/src/persisters/common/database/config.ts
+++ b/src/persisters/common/database/config.ts
@@ -21,7 +21,12 @@ export type DefaultedJsonConfig = [
 ];
 export type DefaultedTabularConfig = [
   tablesLoadConfig: IdMap<
-    [tableId: Id, rowIdColumnName: string, whereCondition: string | null]
+    [
+      tableId: Id,
+      rowIdColumnName: string,
+      whereCondition: string | null,
+      whenCondition: string | null,
+    ]
   >,
   tablesSaveConfig: IdMap<
     [
@@ -51,7 +56,7 @@ const TABLE_NAME = 'tableName';
 const DELETE_EMPTY_COLUMNS = 'deleteEmptyColumns';
 const DELETE_EMPTY_TABLE = 'deleteEmptyTable';
 const WHERE_CONDITION = 'whereCondition';
-
+const WHEN_CONDITION = 'whenCondition';
 const DEFAULT_CONFIG: DatabasePersisterConfig = {
   mode: JSON,
   [AUTO_LOAD_INTERVAL_SECONDS]: 1,
@@ -146,6 +151,7 @@ export const getConfigStructures = (
         [TABLE_ID]: null,
         [ROW_ID_COLUMN_NAME]: DEFAULT_ROW_ID_COLUMN_NAME,
         [WHERE_CONDITION]: null,
+        [WHEN_CONDITION]: null,
       },
       TABLE_ID,
       (tableName) => collHas(excludedTableNames, tableName),

--- a/src/persisters/common/database/json.ts
+++ b/src/persisters/common/database/json.ts
@@ -71,6 +71,7 @@ export const createJsonPersister = <
         },
         true,
         true,
+        null,
       );
     });
 

--- a/src/persisters/common/database/postgresql.ts
+++ b/src/persisters/common/database/postgresql.ts
@@ -63,9 +63,8 @@ export const createCustomPostgreSqlPersister = <
     if(!tablesLoadConfig || typeof tablesLoadConfig === 'string') {
       return DEFAULT_WHEN_CONDITION;
     }
-    const [,,whereCondition] = tablesLoadConfig.get(tableName) ?? [];
-    // todo this will need to be different condition as WHEN has different syntax
-    return whereCondition ?? DEFAULT_WHEN_CONDITION;
+    const [,,,whenCondition] = tablesLoadConfig.get(tableName) ?? [];
+    return whenCondition ?? DEFAULT_WHEN_CONDITION;
   };
 
   const addDataTrigger = async (tableName: string) => {

--- a/src/persisters/common/database/postgresql.ts
+++ b/src/persisters/common/database/postgresql.ts
@@ -51,7 +51,7 @@ export const createCustomPostgreSqlPersister = <
   getThing = 'getDb',
 ): Persister<Persist> => {
   const executeCommand = getWrappedCommand(rawExecuteCommand, onSqlCommand);
-  const persisterId = getUniqueId(5);
+  const persisterId = getUniqueId(5).replace(/-/g, '_');
 
   const [isJson, , defaultedConfig, managedTableNamesSet] = getConfigStructures(
     configOrStoreTableName,

--- a/src/persisters/common/database/tabular.ts
+++ b/src/persisters/common/database/tabular.ts
@@ -86,7 +86,7 @@ export const createTabularPersister = <
             rowIdColumnName,
             deleteEmptyColumns,
             deleteEmptyTable,
-            whereCondition,
+            condition,
           ],
           tableId,
         ) => {
@@ -97,7 +97,7 @@ export const createTabularPersister = <
               tables[tableId],
               deleteEmptyColumns,
               deleteEmptyTable,
-              whereCondition,
+              condition,
               partial,
             );
           }
@@ -127,9 +127,9 @@ export const createTabularPersister = <
         await promiseAll(
           mapMap(
             tablesLoadConfig,
-            async ([tableId, rowIdColumnName, whereCondition], tableName) => [
+            async ([tableId, rowIdColumnName, condition], tableName) => [
               tableId,
-              await loadTable(tableName, rowIdColumnName, whereCondition),
+              await loadTable(tableName, rowIdColumnName, condition),
             ],
           ),
         ),

--- a/src/persisters/common/database/tabular.ts
+++ b/src/persisters/common/database/tabular.ts
@@ -81,7 +81,13 @@ export const createTabularPersister = <
       mapMap(
         tablesSaveConfig,
         async (
-          [tableName, rowIdColumnName, deleteEmptyColumns, deleteEmptyTable],
+          [
+            tableName,
+            rowIdColumnName,
+            deleteEmptyColumns,
+            deleteEmptyTable,
+            whereCondition,
+          ],
           tableId,
         ) => {
           if (!partial || objHas(tables, tableId)) {
@@ -91,6 +97,7 @@ export const createTabularPersister = <
               tables[tableId],
               deleteEmptyColumns,
               deleteEmptyTable,
+              whereCondition,
               partial,
             );
           }
@@ -109,6 +116,7 @@ export const createTabularPersister = <
           {[SINGLE_ROW_ID]: values},
           true,
           true,
+          null,
           partial,
         )
       : null;
@@ -119,9 +127,9 @@ export const createTabularPersister = <
         await promiseAll(
           mapMap(
             tablesLoadConfig,
-            async ([tableId, rowIdColumnName], tableName) => [
+            async ([tableId, rowIdColumnName, whereCondition], tableName) => [
               tableId,
-              await loadTable(tableName, rowIdColumnName),
+              await loadTable(tableName, rowIdColumnName, whereCondition),
             ],
           ),
         ),

--- a/test/unit/common/other.ts
+++ b/test/unit/common/other.ts
@@ -27,6 +27,20 @@ export const pause = async (ms = 50, alsoNudgeHlc = false): Promise<void> => {
   return promise;
 };
 
+export const waitFor = async (assert: () => any, timeoutMs = 50) => {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      await assert();
+      return;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (err) {
+      await pause(10, true);
+    }
+  }
+  return assert();
+};
+
 export const mockFetchWasm = (): void => {
   fetchMock.enableMocks();
   fetchMock.resetMocks();

--- a/test/unit/persisters/database/json.test.ts
+++ b/test/unit/persisters/database/json.test.ts
@@ -1,4 +1,4 @@
-import {mockFetchWasm, pause} from '../../common/other.ts';
+import {mockFetchWasm, pause, waitFor} from '../../common/other.ts';
 import {ALL_VARIANTS, getDatabaseFunctions} from '../common/databases.ts';
 import 'fake-indexeddb/auto';
 import type {Store} from 'tinybase';
@@ -579,7 +579,9 @@ describe.each(Object.entries(ALL_VARIANTS))(
         store.setTables({t1: {r1: {c1: 1}}}).setValues({v1: 1});
         await persister.save();
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        }, 1000);
       });
 
       test('autoSave1 & autoLoad2', async () => {
@@ -588,7 +590,10 @@ describe.each(Object.entries(ALL_VARIANTS))(
         await pause(autoLoadPause);
         store.setTables({t1: {r1: {c1: 1}}}).setValues({v1: 1});
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        await waitFor(() => {
+          // todo this is failing
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        }, 1000);
       });
 
       test('autoSave1 & autoLoad2, complex transactions', async () => {

--- a/test/unit/persisters/database/mergeable-json.test.ts
+++ b/test/unit/persisters/database/mergeable-json.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 import {resetHlc} from '../../common/mergeable.ts';
-import {mockFetchWasm, pause} from '../../common/other.ts';
+import {mockFetchWasm, pause, waitFor} from '../../common/other.ts';
 import {MERGEABLE_VARIANTS, getDatabaseFunctions} from '../common/databases.ts';
 import 'fake-indexeddb/auto';
 import type {MergeableStore} from 'tinybase';
@@ -374,7 +374,9 @@ describe.each(Object.entries(MERGEABLE_VARIANTS))(
         store.setTables({t1: {r1: {c1: 1}}}).setValues({v1: 1});
         await persister.save();
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        }, 1000);
       });
 
       test('autoSave1 & autoLoad2', async () => {
@@ -383,7 +385,9 @@ describe.each(Object.entries(MERGEABLE_VARIANTS))(
         await pause(autoLoadPause);
         store.setTables({t1: {r1: {c1: 1}}}).setValues({v1: 1});
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        }, 1000);
       });
 
       test('autoSave1 & autoLoad2, complex transactions', async () => {
@@ -397,40 +401,54 @@ describe.each(Object.entries(MERGEABLE_VARIANTS))(
           })
           .setValues({v1: 1, v2: 2});
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 1, c2: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 1, c2: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store.setCell('t1', 'r1', 'c1', 2);
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 2, c2: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 2, c2: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store.delCell('t1', 'r1', 'c2');
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store.delRow('t1', 'r2');
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 2}}, t2: {r1: {c1: 1}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 2}}, t2: {r1: {c1: 1}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store.delTable('t2');
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 2}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 2}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store.delValue('v2');
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 1}]);
+        }, 1000);
         store.setValue('v1', 2);
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 2}]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 2}]);
+        }, 1000);
       }, 20000);
     });
 

--- a/test/unit/persisters/database/tabular.test.ts
+++ b/test/unit/persisters/database/tabular.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable max-len */
-import {mockFetchWasm, pause} from '../../common/other.ts';
+import {mockFetchWasm, pause, waitFor} from '../../common/other.ts';
 import {ALL_VARIANTS, getDatabaseFunctions} from '../common/databases.ts';
 import 'fake-indexeddb/auto';
 import type {Store} from 'tinybase';
@@ -474,7 +474,7 @@ describe.each(Object.entries(ALL_VARIANTS))(
           mode: 'tabular',
           tables: {
             load: {t1: 't1', t2: 't2', t3: 't3'},
-            save: {t1: 't1', t2: 't2', t3: 't3'}, // todo
+            save: {t1: 't1', t2: 't2', t3: 't3'},
           },
           values: {load: true, save: true},
           autoLoadIntervalSeconds,
@@ -872,7 +872,7 @@ describe.each(Object.entries(ALL_VARIANTS))(
           },
           values: {load: true, save: true},
           autoLoadIntervalSeconds,
-        });
+        }, undefined, (err) => console.error(err));
       });
 
       test('nothing', async () => {
@@ -1074,16 +1074,22 @@ describe.each(Object.entries(ALL_VARIANTS))(
         });
         await persister.startAutoLoad();
         await pause(autoLoadPause);
-        expect(store.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        }, 1000);
         await cmd(db, 'UPDATE t1 SET c1=$1 WHERE _id=$2', [2, 'r1']);
         await pause(autoLoadPause);
-        expect(store.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 1}]);
+        }, 1000);
         await cmd(db, 'UPDATE tinybase_values SET v1=$1 WHERE _id=$2', [
           2,
           '_',
         ]);
         await pause(autoLoadPause);
-        expect(store.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 2}]);
+        await waitFor(() => {
+          expect(store.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 2}]);
+        }, 1000);
       });
 
       test('autoLoad, table dropped and recreated', async () => {
@@ -1122,7 +1128,9 @@ describe.each(Object.entries(ALL_VARIANTS))(
         );
         await cmd(db, 'INSERT INTO t1 (_id, c1) VALUES ($1, $2)', ['r1', 3]);
         await pause(autoLoadPause);
-        expect(store.getContent()).toEqual([{t1: {r1: {c1: 3}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store.getContent()).toEqual([{t1: {r1: {c1: 3}}}, {v1: 1}]);
+        }, 1000);
         await cmd(db, 'DROP TABLE tinybase_values');
         await cmd(
           db,
@@ -1137,14 +1145,18 @@ describe.each(Object.entries(ALL_VARIANTS))(
           3,
         ]);
         await pause(autoLoadPause);
-        expect(store.getContent()).toEqual([{t1: {r1: {c1: 3}}}, {v1: 3}]);
+        await waitFor(() => {
+          expect(store.getContent()).toEqual([{t1: {r1: {c1: 3}}}, {v1: 3}]);
+        }, 1000);
         await cmd(db, 'UPDATE t1 SET c1 = $1 WHERE _id = $2', [4, 'r1']);
         await cmd(db, 'UPDATE tinybase_values SET v1 = $1 WHERE _id = $2', [
           4,
           '_',
         ]);
         await pause(autoLoadPause);
-        expect(store.getContent()).toEqual([{t1: {r1: {c1: 4}}}, {v1: 4}]);
+        await waitFor(() => {
+          expect(store.getContent()).toEqual([{t1: {r1: {c1: 4}}}, {v1: 4}]);
+        }, 1000);
       });
     });
 
@@ -1232,7 +1244,7 @@ describe.each(Object.entries(ALL_VARIANTS))(
             'INSERT INTO"t2"("_id","c1")VALUES($1,$2)ON CONFLICT("_id")DO UPDATE SET"c1"=excluded."c1"',
             ['r1', encodedValue(1)],
           ],
-          ['DELETE FROM"t1"WHERE"_id"NOT IN($1,$2) AND true', ['r1', 'r2']], //todo
+          ['DELETE FROM"t1"WHERE"_id"NOT IN($1,$2) AND true', ['r1', 'r2']],
           ['DELETE FROM"t2"WHERE"_id"NOT IN($1) AND true', ['r1']],
           [
             'CREATE TABLE"tinybase_values"("_id"' +
@@ -1697,7 +1709,10 @@ describe.each(Object.entries(ALL_VARIANTS))(
         store1.setTables({t1: {r1: {c1: 1}}}).setValues({v1: 1});
         await persister1.save();
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        // todo this is failing
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        }, 1000);
       });
 
       test('autoSave1 & autoLoad2', async () => {
@@ -1706,7 +1721,9 @@ describe.each(Object.entries(ALL_VARIANTS))(
         await pause(autoLoadPause);
         store1.setTables({t1: {r1: {c1: 1}}}).setValues({v1: 1});
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 1}}}, {v1: 1}]);
+        }, 1000);
       });
 
       test('autoSave1 & autoLoad2, complex transactions', async () => {
@@ -1721,40 +1738,54 @@ describe.each(Object.entries(ALL_VARIANTS))(
           {v1: 1, v2: 2},
         ]);
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 1, c2: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 1, c2: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store1.setCell('t1', 'r1', 'c1', 2);
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 2, c2: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 2, c2: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store1.delCell('t1', 'r1', 'c2');
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 2}, r2: {c1: 1}}, t2: {r1: {c1: 1}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store1.delRow('t1', 'r2');
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 2}}, t2: {r1: {c1: 1}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 2}}, t2: {r1: {c1: 1}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store1.delTable('t2');
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([
-          {t1: {r1: {c1: 2}}},
-          {v1: 1, v2: 2},
-        ]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([
+            {t1: {r1: {c1: 2}}},
+            {v1: 1, v2: 2},
+          ]);
+        }, 1000);
         store1.delValue('v2');
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 1}]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 1}]);
+        }, 1000);
         store1.setValue('v1', 2);
         await pause(autoLoadPause);
-        expect(store2.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 2}]);
+        await waitFor(() => {
+          expect(store2.getContent()).toEqual([{t1: {r1: {c1: 2}}}, {v1: 2}]);
+        }, 1000);
       }, 20000);
     });
 

--- a/test/unit/persisters/database/tabular.test.ts
+++ b/test/unit/persisters/database/tabular.test.ts
@@ -1244,8 +1244,8 @@ describe.each(Object.entries(ALL_VARIANTS))(
             'INSERT INTO"t2"("_id","c1")VALUES($1,$2)ON CONFLICT("_id")DO UPDATE SET"c1"=excluded."c1"',
             ['r1', encodedValue(1)],
           ],
-          ['DELETE FROM"t1"WHERE"_id"NOT IN($1,$2) AND true', ['r1', 'r2']],
-          ['DELETE FROM"t2"WHERE"_id"NOT IN($1) AND true', ['r1']],
+          ['DELETE FROM"t1"WHERE"_id"NOT IN($1,$2) AND ( true)', ['r1', 'r2']],
+          ['DELETE FROM"t2"WHERE"_id"NOT IN($1) AND ( true)', ['r1']],
           [
             'CREATE TABLE"tinybase_values"("_id"' +
               columnType +
@@ -1260,7 +1260,7 @@ describe.each(Object.entries(ALL_VARIANTS))(
             'INSERT INTO"tinybase_values"("_id","v1","v2")VALUES($1,$2,$3)ON CONFLICT("_id")DO UPDATE SET"v1"=excluded."v1","v2"=excluded."v2"',
             ['_', encodedValue(1), encodedValue(2)],
           ],
-          ['DELETE FROM"tinybase_values"WHERE"_id"NOT IN($1) AND true', ['_']],
+          ['DELETE FROM"tinybase_values"WHERE"_id"NOT IN($1) AND ( true)', ['_']],
           ['END', undefined],
         ]);
       });
@@ -1539,7 +1539,7 @@ describe.each(Object.entries(ALL_VARIANTS))(
           });
           sqlCheck(sqlLogs, [
             ['BEGIN', undefined],
-            ['DELETE FROM"t1"WHERE"_id"=$1', ['r1']],
+            ['DELETE FROM"t1"WHERE ("_id"=$1) AND ( true)', ['r1']],
             ['END', undefined],
           ]);
         });

--- a/test/unit/persisters/database/tabular.test.ts
+++ b/test/unit/persisters/database/tabular.test.ts
@@ -120,7 +120,7 @@ describe.each(Object.entries(ALL_VARIANTS))(
                     t5: false,
                     t6: {
                       tableName: 't6',
-                      whereCondition: isPostgres ? 'c6 = \'1\'' : 'c6 = 1',
+                      condition: isPostgres ? '$tableName.c6 = \'1\'' : '$tableName.c6 = 1',
                     },
                   },
                   autoLoadIntervalSeconds,
@@ -359,7 +359,7 @@ describe.each(Object.entries(ALL_VARIANTS))(
                     t5: false,
                     t6: {
                       tableId: 't6',
-                      whereCondition: isPostgres ? 'c6 = \'1\'' : 'c6 = 1',
+                      condition: isPostgres ? '$tableName.c6 = \'1\'' : '$tableName.c6 = 1',
                     },
                     tinybase_values: {tableId: 'values'},
                   },
@@ -599,7 +599,7 @@ describe.each(Object.entries(ALL_VARIANTS))(
               .setCell('t1', 'r3', 'c3', 3);
             const persister = await getPersister(store, db, {
               mode: 'tabular',
-              tables: {save: {t1: {tableName: 't1', whereCondition: isPostgres ? 'c0 = \'1\'' : 'c0 = 1'}}},
+              tables: {save: {t1: {tableName: 't1', condition: isPostgres ? '$tableName.c0 = \'1\'' : '$tableName.c0 = 1'}}},
               values: {save: true},
               autoLoadIntervalSeconds,
             });


### PR DESCRIPTION
## Summary
Implements #233 

Add a `whereCondition` option to tabular persister to allow scoping TinyBase sync to just part of the table. This is useful for use-case where we want to have store for slice of the data, eg project, branch, org, ....

## How did you test this change?

So far I've tested only using unit tests, and would appreciate a bit of help and/or guidance how to test this properly.