### PR TITLE
Support postgres schemas

### DIFF
--- a/src/persisters/common/database/common.ts
+++ b/src/persisters/common/database/common.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../../@types/persisters/index.d.ts';
 import {arrayJoin, arrayMap} from '../../../common/array.ts';
 import {IdSet} from '../../../common/set.ts';
-import {COMMA, strReplace, TRUE} from '../../../common/strings.ts';
+import {COMMA, strReplace, strSplit, TRUE} from '../../../common/strings.ts';
 
 export type QuerySchema = (
   executeCommand: DatabaseExecuteCommand,
@@ -55,7 +55,11 @@ export const getWrappedCommand = (
       }
     : executeCommand;
 
-export const escapeId = (str: string) => `"${strReplace(str, /"/g, '""')}"`;
+export const escapeId = (str: string) =>
+  arrayJoin(
+    arrayMap(strSplit(str, '.'), (part) => `"${strReplace(part, /"/g, '""')}"`),
+    '.',
+  );
 
 export const escapeIds = (...ids: Ids) => escapeId(arrayJoin(ids, '_'));
 


### PR DESCRIPTION
## Summary
To support postgres schemas the only thing we need is to update the escaping function.

Closes #242 

## How did you test this change?

I've tested it manually, but I haven't found a good way how to test this without doing unrelated changes, because the `/test` folder has it's own `tsconfig` and doesn't have access directly to the src files that are not exposed. Which seems to be by design. But all tests of databases run over all engines and this isn't supported by SQLite to add it to the rest of sql tests.