### PR TITLE
fix: define react-native-sqlite-storage as optional peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
     "react-dom": {
       "optional": true
     },
+    "react-native-sqlite-storage": {
+      "optional": true
+    },
     "sqlite3": {
       "optional": true
     },


### PR DESCRIPTION
## Summary

After installing the latest version `tinybase@6.4.0` you get the following warning 

```
YN0002: │ X:. doesn't provide react-native-sqlite-storage (pc34f6), requested by tinybase.
```

## How did you test this change?

Made sure to set it as optional to avoid getting this warning