### PR TITLE
Call listeners added from definable inside a transaction

### DIFF
--- a/src/checkpoints/index.ts
+++ b/src/checkpoints/index.ts
@@ -96,7 +96,7 @@ export const createCheckpoints = getCreateFunction(
     const clearCheckpointId = (checkpointId: Id): void => {
       mapSet(deltas, checkpointId);
       mapSet(labels, checkpointId);
-      callListeners(checkpointListeners, [checkpointId]);
+      callListeners(false, checkpointListeners, [checkpointId]);
     };
 
     const clearCheckpointIds = (checkpointIds: Ids, to?: number): void =>
@@ -157,7 +157,7 @@ export const createCheckpoints = getCreateFunction(
 
     const callListenersIfChanged = (): void => {
       if (checkpointsChanged) {
-        callListeners(checkpointIdsListeners);
+        callListeners(false, checkpointIdsListeners);
         checkpointsChanged = 0;
       }
     };
@@ -180,7 +180,7 @@ export const createCheckpoints = getCreateFunction(
         mapGet(labels, checkpointId) !== label
       ) {
         mapSet(labels, checkpointId, label);
-        callListeners(checkpointListeners, [checkpointId]);
+        callListeners(false, checkpointListeners, [checkpointId]);
       }
       return checkpoints;
     };
@@ -227,12 +227,12 @@ export const createCheckpoints = getCreateFunction(
     };
 
     const addCheckpointIdsListener = (listener: CheckpointIdsListener): Id =>
-      addListener(listener, checkpointIdsListeners);
+      addListener(false, listener, checkpointIdsListeners);
 
     const addCheckpointListener = (
       checkpointId: IdOrNull,
       listener: CheckpointListener,
-    ): Id => addListener(listener, checkpointListeners, [checkpointId]);
+    ): Id => addListener(false, listener, checkpointListeners, [checkpointId]);
 
     const delListener = (listenerId: Id): Checkpoints => {
       delListenerImpl(listenerId);
@@ -254,7 +254,7 @@ export const createCheckpoints = getCreateFunction(
     const clearForward = (): Checkpoints => {
       if (!arrayIsEmpty(forwardIds)) {
         clearCheckpointIds(forwardIds);
-        callListeners(checkpointIdsListeners);
+        callListeners(false, checkpointIdsListeners);
       }
       return checkpoints;
     };

--- a/src/common/definable.ts
+++ b/src/common/definable.ts
@@ -124,7 +124,7 @@ export const getDefinableFunctions = <Thing, RowValue>(
       mapSet(things, id, getDefaultThing());
       mapSet(allRowValues, id, mapNew());
       mapSet(allSortKeys, id, mapNew());
-      callListeners(thingIdListeners);
+      callListeners(true, thingIdListeners);
     }
   };
 
@@ -206,10 +206,15 @@ export const getDefinableFunctions = <Thing, RowValue>(
     addStoreListeners(
       id,
       0,
-      store.addRowListener(tableId, null, (_store, _tableId, rowId) =>
-        processRow(rowId),
+      store.addRowListener.call(
+        {isInternal: true},
+        tableId,
+        null,
+        (_store, _tableId, rowId) => processRow(rowId),
       ),
-      store.addTableListener(tableId, () => processTable()),
+      store.addTableListener.call({isInternal: true}, tableId, () =>
+        processTable(),
+      ),
     );
   };
 
@@ -219,11 +224,11 @@ export const getDefinableFunctions = <Thing, RowValue>(
     mapSet(allRowValues, id);
     mapSet(allSortKeys, id);
     delStoreListeners(id);
-    callListeners(thingIdListeners);
+    callListeners(false, thingIdListeners);
   };
 
   const addThingIdsListener = (listener: () => void) =>
-    addListener(listener, thingIdListeners);
+    addListener(false, listener, thingIdListeners);
 
   const destroy = (): void => mapForEach(storeListenerIds, delDefinition);
 

--- a/src/indexes/index.ts
+++ b/src/indexes/index.ts
@@ -204,10 +204,10 @@ export const createIndexes = getCreateFunction((store: Store): Indexes => {
         }
 
         if (sliceIdsChanged) {
-          callListeners(sliceIdsListeners, [indexId]);
+          callListeners(false, sliceIdsListeners, [indexId]);
         }
         collForEach(changedSlices, (sliceId) =>
-          callListeners(sliceRowIdsListeners, [indexId, sliceId]),
+          callListeners(false, sliceRowIdsListeners, [indexId, sliceId]),
         );
       },
       getRowCellFunction(getSliceIdOrIds),
@@ -256,13 +256,14 @@ export const createIndexes = getCreateFunction((store: Store): Indexes => {
   const addSliceIdsListener = (
     indexId: IdOrNull,
     listener: SliceIdsListener,
-  ): Id => addListener(listener, sliceIdsListeners, [indexId]);
+  ): Id => addListener(false, listener, sliceIdsListeners, [indexId]);
 
   const addSliceRowIdsListener = (
     indexId: IdOrNull,
     sliceId: IdOrNull,
     listener: SliceRowIdsListener,
-  ): Id => addListener(listener, sliceRowIdsListeners, [indexId, sliceId]);
+  ): Id =>
+    addListener(false, listener, sliceRowIdsListeners, [indexId, sliceId]);
 
   const delListener = (listenerId: Id): Indexes => {
     delListenerImpl(listenerId);

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -116,7 +116,13 @@ export const createMetrics = getCreateFunction((store: Store): Metrics => {
 
         if (newMetric != oldMetric) {
           setMetric(metricId, newMetric);
-          callListeners(metricListeners, [metricId], newMetric, oldMetric);
+          callListeners(
+            false,
+            metricListeners,
+            [metricId],
+            newMetric,
+            oldMetric,
+          );
         }
       },
       getRowCellFunction(getNumber, 1),
@@ -132,7 +138,7 @@ export const createMetrics = getCreateFunction((store: Store): Metrics => {
   const addMetricListener = (
     metricId: IdOrNull,
     listener: MetricListener,
-  ): Id => addListener(listener, metricListeners, [metricId]);
+  ): Id => addListener(false, listener, metricListeners, [metricId]);
 
   const delListener = (listenerId: Id): Metrics => {
     delListenerImpl(listenerId);

--- a/src/persisters/common/create.ts
+++ b/src/persisters/common/create.ts
@@ -149,7 +149,7 @@ export const createCustomPersister = <
   const setStatus = (newStatus: StatusValues): void => {
     if (newStatus != status) {
       status = newStatus;
-      callListeners(statusListeners, undefined, status);
+      callListeners(false, statusListeners, undefined, status);
     }
   };
 
@@ -332,7 +332,7 @@ export const createCustomPersister = <
   const getStatus = (): StatusValues => status;
 
   const addStatusListener = (listener: StatusListener): Id =>
-    addListener(listener, statusListeners);
+    addListener(false, listener, statusListeners);
 
   const delListener = (listenerId: Id): Store => {
     delListenerImpl(listenerId);

--- a/src/relationships/index.ts
+++ b/src/relationships/index.ts
@@ -164,14 +164,23 @@ export const createRelationships = getCreateFunction(
           change();
 
           collForEach(changedLocalRows, (localRowId) =>
-            callListeners(remoteRowIdListeners, [relationshipId, localRowId]),
+            callListeners(false, remoteRowIdListeners, [
+              relationshipId,
+              localRowId,
+            ]),
           );
           collForEach(changedRemoteRows, (remoteRowId) =>
-            callListeners(localRowIdsListeners, [relationshipId, remoteRowId]),
+            callListeners(false, localRowIdsListeners, [
+              relationshipId,
+              remoteRowId,
+            ]),
           );
           collForEach(changedLinkedRows, (firstRowId) => {
             delLinkedRowIdsCache(relationshipId, firstRowId);
-            callListeners(linkedRowIdsListeners, [relationshipId, firstRowId]);
+            callListeners(false, linkedRowIdsListeners, [
+              relationshipId,
+              firstRowId,
+            ]);
           });
         },
         getRowCellFunction(getRemoteRowId),
@@ -219,14 +228,17 @@ export const createRelationships = getCreateFunction(
       localRowId: IdOrNull,
       listener: RemoteRowIdListener,
     ): Id =>
-      addListener(listener, remoteRowIdListeners, [relationshipId, localRowId]);
+      addListener(false, listener, remoteRowIdListeners, [
+        relationshipId,
+        localRowId,
+      ]);
 
     const addLocalRowIdsListener = (
       relationshipId: IdOrNull,
       remoteRowId: IdOrNull,
       listener: LocalRowIdsListener,
     ): Id =>
-      addListener(listener, localRowIdsListeners, [
+      addListener(false, listener, localRowIdsListeners, [
         relationshipId,
         remoteRowId,
       ]);
@@ -237,7 +249,7 @@ export const createRelationships = getCreateFunction(
       listener: LinkedRowIdsListener,
     ): Id => {
       getLinkedRowIdsCache(relationshipId, firstRowId);
-      return addListener(listener, linkedRowIdsListeners, [
+      return addListener(false, listener, linkedRowIdsListeners, [
         relationshipId,
         firstRowId,
       ]);

--- a/src/synchronizers/synchronizer-ws-server/index.ts
+++ b/src/synchronizers/synchronizer-ws-server/index.ts
@@ -192,11 +192,11 @@ export const createWsServer = (<
         );
 
         if (collIsEmpty(clients)) {
-          callListeners(pathIdListeners, undefined, pathId, 1);
+          callListeners(false, pathIdListeners, undefined, pathId, 1);
           await configureServerClient(serverClient, pathId, clients);
         }
         mapSet(clients, clientId, client);
-        callListeners(clientIdListeners, [pathId], clientId, 1);
+        callListeners(false, clientIdListeners, [pathId], clientId, 1);
 
         client.on(MESSAGE, (data) => {
           const payload = data.toString(UTF8);
@@ -215,12 +215,12 @@ export const createWsServer = (<
 
         client.on('close', async () => {
           collDel(clients, clientId);
-          callListeners(clientIdListeners, [pathId], clientId, -1);
+          callListeners(false, clientIdListeners, [pathId], clientId, -1);
           if (collIsEmpty(clients)) {
             await stopServerClient(serverClient);
             collDel(serverClientsByPath, pathId);
             collDel(clientsByPath, pathId);
-            callListeners(pathIdListeners, undefined, pathId, -1);
+            callListeners(false, pathIdListeners, undefined, pathId, -1);
           }
         });
 
@@ -243,12 +243,12 @@ export const createWsServer = (<
     mapKeys(mapGet(clientsByPath, pathId));
 
   const addPathIdsListener = (listener: PathIdsListener) =>
-    addListener(listener, pathIdListeners);
+    addListener(false, listener, pathIdListeners);
 
   const addClientIdsListener = (
     pathId: IdOrNull,
     listener: ClientIdsListener,
-  ) => addListener(listener, clientIdListeners, [pathId]);
+  ) => addListener(false, listener, clientIdListeners, [pathId]);
 
   const delListener = (listenerId: Id): WsServer => {
     delListenerImpl(listenerId);


### PR DESCRIPTION
At the moment, indexes are not immediately updated when a mutation is called within a transaction. This code ensure they remain updated.

## Summary

Explain the motivation for making this change. What problem does it solve?

## How did you test this change?

Please provide evidence that you have tested this change under various
circumstances.
