### PR TITLE
add DO persister tests, fix prefix parsing, fix empty storage handling

### DIFF
--- a/src/persisters/persister-durable-object-storage/index.ts
+++ b/src/persisters/persister-durable-object-storage/index.ts
@@ -43,7 +43,7 @@ export const createDurableObjectStoragePersister = ((
     key: string,
   ): [type: string, ...ids: Ids] | undefined => {
     if (strStartsWith(key, storagePrefix)) {
-      const type = slice(key, storagePrefix.length, 1);
+      const type = slice(key, storagePrefix.length, storagePrefix.length + 1);
       return type == T || type == V
         ? [
             type,
@@ -54,7 +54,7 @@ export const createDurableObjectStoragePersister = ((
   };
 
   const getPersisted = async (): Promise<
-    PersistedContent<PersistsType.MergeableStoreOnly>
+    PersistedContent<PersistsType.MergeableStoreOnly> | undefined
   > => {
     const tables: TablesStamp<true> = stampNewObjectWithHash();
     const values: ValuesStamp<true> = stampNewObjectWithHash();
@@ -100,6 +100,9 @@ export const createDurableObjectStoragePersister = ((
               : 0,
         ),
     );
+    if (Object.keys(tables[0]).length === 0 && Object.keys(values[0]).length === 0) {
+      return undefined;
+    }
     return [tables, values];
   };
 

--- a/test/unit/persisters/__snapshots__/mergeable.test.ts.snap
+++ b/test/unit/persisters/__snapshots__/mergeable.test.ts.snap
@@ -662,6 +662,96 @@ exports[`Persists to/from customSynchronizer > saves 2`] = `
 ]
 `;
 
+exports[`Persists to/from durableObjectStorage > autoSaves > delCell 1`] = `undefined`;
+
+exports[`Persists to/from durableObjectStorage > autoSaves > delValue 1`] = `undefined`;
+
+exports[`Persists to/from durableObjectStorage > autoSaves > initial 1`] = `undefined`;
+
+exports[`Persists to/from durableObjectStorage > autoSaves > setTables 1`] = `undefined`;
+
+exports[`Persists to/from durableObjectStorage > autoSaves > setValues 1`] = `undefined`;
+
+exports[`Persists to/from durableObjectStorage > loads 1`] = `
+[
+  [
+    {
+      "t1": [
+        {
+          "r1": [
+            {
+              "c1": [
+                1,
+                "_",
+                4065945599,
+              ],
+            },
+            "",
+            1279994494,
+          ],
+        },
+        "",
+        1293085726,
+      ],
+    },
+    "",
+    4033596827,
+  ],
+  [
+    {
+      "v1": [
+        1,
+        "_",
+        4065945599,
+      ],
+    },
+    "",
+    2304392760,
+  ],
+]
+`;
+
+exports[`Persists to/from durableObjectStorage > saves 1`] = `
+[
+  [
+    {
+      "t1": [
+        {
+          "r1": [
+            {
+              "c1": [
+                1,
+                "Nn1JUF-----7JQY8",
+                1003668370,
+              ],
+            },
+            "",
+            550994372,
+          ],
+        },
+        "",
+        1072852846,
+      ],
+    },
+    "",
+    1771939739,
+  ],
+  [
+    {
+      "v1": [
+        1,
+        "Nn1JUF----07JQY8",
+        1130939691,
+      ],
+    },
+    "",
+    3877632732,
+  ],
+]
+`;
+
+exports[`Persists to/from durableObjectStorage > saves 2`] = `undefined`;
+
 exports[`Persists to/from file > autoLoads 1`] = `
 [
   [

--- a/test/unit/persisters/common/mocks.ts
+++ b/test/unit/persisters/common/mocks.ts
@@ -28,6 +28,7 @@ import {
   createOpfsPersister,
   createSessionPersister,
 } from 'tinybase/persisters/persister-browser';
+import {createDurableObjectStoragePersister} from 'tinybase/persisters/persister-durable-object-storage';
 import {createFilePersister} from 'tinybase/persisters/persister-file';
 import {createIndexedDbPersister} from 'tinybase/persisters/persister-indexed-db';
 import {createRemotePersister} from 'tinybase/persisters/persister-remote';
@@ -777,4 +778,134 @@ export const mockAutomerge: Persistable<DocHandle<any>> = {
   del: async (docHandle: DocHandle<any>): Promise<void> => docHandle.delete(),
   testMissing: false,
   testAutoLoad: true,
+};
+
+// Mock DurableObjectStorage - simple Map-based implementation
+class MockDurableObjectStorage {
+  private data = new Map<string, any>();
+
+  async get<T>(key: string): Promise<T | undefined>;
+  async get<T>(keys: string[]): Promise<Map<string, T>>;
+  async get<T>(
+    keyOrKeys: string | string[],
+  ): Promise<T | undefined | Map<string, T>> {
+    if (Array.isArray(keyOrKeys)) {
+      const result = new Map<string, T>();
+      for (const key of keyOrKeys) {
+        const value = this.data.get(key);
+        if (value !== undefined) result.set(key, value);
+      }
+      return result;
+    }
+    return this.data.get(keyOrKeys);
+  }
+
+  async put(entries: Record<string, any>): Promise<void> {
+    for (const [key, value] of Object.entries(entries)) {
+      this.data.set(key, value);
+    }
+  }
+
+  async list<T>(options?: {prefix?: string}): Promise<Map<string, T>> {
+    const result = new Map<string, T>();
+    const prefix = options?.prefix ?? '';
+    for (const [key, value] of this.data.entries()) {
+      if (key.startsWith(prefix)) {
+        result.set(key, value);
+      }
+    }
+    return result;
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.data.delete(key);
+  }
+
+  clear(): void {
+    this.data.clear();
+  }
+}
+
+const STORAGE_PREFIX = 'tinybase_';
+const T = 't';
+const V = 'v';
+
+// Key construction matching the persister's format
+const constructStorageKey = (type: string, ...ids: string[]) =>
+  STORAGE_PREFIX + type + JSON.stringify(ids).slice(1, -1);
+
+export const mockDurableObjectStorage: Persistable<MockDurableObjectStorage> = {
+  autoLoadPause: 10,
+  getLocation: async () => new MockDurableObjectStorage(),
+  getLocationMethod: ['getStorage', (storage) => storage],
+  getPersister: (
+    store: Store | MergeableStore,
+    storage: MockDurableObjectStorage,
+  ) =>
+    createDurableObjectStoragePersister(
+      store as MergeableStore,
+      storage as unknown as DurableObjectStorage,
+      STORAGE_PREFIX,
+    ),
+  get: async (
+    storage: MockDurableObjectStorage,
+  ): Promise<MergeableContent | void> => {
+    const entries = await storage.list({prefix: STORAGE_PREFIX});
+    if (entries.size > 0) {
+      return undefined;
+    }
+  },
+  set: async (
+    storage: MockDurableObjectStorage,
+    content: Content | MergeableContent,
+  ): Promise<void> => {
+    // Convert MergeableContent to the key-value format the persister uses
+    const [[tablesObj, tablesHlc, tablesHash], [valuesObj, valuesHlc, valuesHash]] =
+      content as MergeableContent;
+    const entries: Record<string, any> = {};
+
+    // Store tables root
+    entries[constructStorageKey(T)] = [0, tablesHlc, tablesHash];
+
+    // Process tables
+    Object.entries(tablesObj).forEach(
+      ([tableId, [tableObj, tableHlc, tableHash]]: any) => {
+        entries[constructStorageKey(T, tableId)] = [0, tableHlc, tableHash];
+        Object.entries(tableObj).forEach(
+          ([rowId, [rowObj, rowHlc, rowHash]]: any) => {
+            entries[constructStorageKey(T, tableId, rowId)] = [
+              0,
+              rowHlc,
+              rowHash,
+            ];
+            Object.entries(rowObj).forEach(([cellId, cellStamp]) => {
+              entries[constructStorageKey(T, tableId, rowId, cellId)] =
+                cellStamp;
+            });
+          },
+        );
+      },
+    );
+
+    // Store values root
+    entries[constructStorageKey(V)] = [0, valuesHlc, valuesHash];
+
+    // Process values
+    Object.entries(valuesObj).forEach(([valueId, valueStamp]) => {
+      entries[constructStorageKey(V, valueId)] = valueStamp;
+    });
+
+    await storage.put(entries);
+  },
+  write: async (
+    _storage: MockDurableObjectStorage,
+    _rawContent: any,
+  ): Promise<void> => {
+    // Not used for DO storage
+  },
+  del: async (storage: MockDurableObjectStorage): Promise<void> => {
+    storage.clear();
+  },
+  testMissing: false,
+  testAutoLoad: false,
 };

--- a/test/unit/persisters/mergeable.test.ts
+++ b/test/unit/persisters/mergeable.test.ts
@@ -15,6 +15,7 @@ import {MERGEABLE_VARIANTS} from './common/databases.ts';
 import {
   getMockDatabases,
   mockCustomSynchronizer,
+  mockDurableObjectStorage,
   mockFile,
   mockLocalStorage,
   mockLocalSynchronizer,
@@ -40,6 +41,7 @@ describe.each([
   ['opfs', mockOpfs],
   ['localStorage', mockLocalStorage],
   ['sessionStorage', mockSessionStorage],
+  ['durableObjectStorage', mockDurableObjectStorage],
   ['localSynchronizer', mockLocalSynchronizer],
   ['customSynchronizer', mockCustomSynchronizer],
   ...getMockDatabases(MERGEABLE_VARIANTS),


### PR DESCRIPTION
## Summary

  Fixes two bugs in the Durable Object Storage persister when using a non-empty storagePrefix:

  1. Prefix parsing bug (line 46): slice(key, storagePrefix.length, 1) returns empty string when prefix length > 1. Fixed to slice(key, storagePrefix.length, storagePrefix.length + 1).
  2. Empty storage handling (line 103-105): getPersisted() returned valid-but-empty content [[{}, '', 0], [{}, '', 0]] when storage was empty, causing load() to wipe existing store data. Now returns undefined when no data exists.

## How did you test this change?

There were formerly no tests (!) for this persistence provider.  I added a mock structure which allows it to be tested in a way that I believe is idiomatic with the other providers.  Initially the first bug was my target, but I discovered the second when I got the test suite to run.
