### PR TITLE
Fix sync propagation for mutating listener deletions

### DIFF
--- a/src/persisters/common/create.ts
+++ b/src/persisters/common/create.ts
@@ -270,7 +270,10 @@ export const createCustomPersister = <
     >,
   ): Promise<Persister<Persist>> => {
     /*! istanbul ignore else */
-    if (status != StatusValues.Loading) {
+    if (
+      status != StatusValues.Loading ||
+      ((isSynchronizer as 0 | 1) && !isUndefined(changes))
+    ) {
       setStatus(StatusValues.Saving);
       saves++;
       await schedule(async () => {

--- a/test/unit/synchronizers/synchronizers.test.ts
+++ b/test/unit/synchronizers/synchronizers.test.ts
@@ -548,6 +548,29 @@ describe.each([
         ]);
       });
 
+      test('mutating listener deletions during sync are propagated back', async () => {
+        store2.addRowListener(
+          'tasks',
+          null,
+          (_store, _tableId, rowId) => {
+            if (store2.getCell('tasks', rowId, 'pending') === false) {
+              store2.delRow('tasks', rowId);
+            }
+          },
+          true,
+        );
+
+        store1.setRow('tasks', 'task1', {
+          pending: false,
+          title: 'demo',
+        });
+
+        await pause(synchronizable.pauseMilliseconds);
+
+        expect(store1.getTable('tasks')).toEqual({});
+        expect(store2.getTable('tasks')).toEqual({});
+      });
+
       test('deleted cell', async () => {
         store1.setContent([
           {t1: {r1: {c1: 1, c2: 2}, r2: {c2: 2}}, t2: {r2: {c2: 2}}},


### PR DESCRIPTION
## Summary

This change fixes a sync gap where mutations triggered by a mutating listener were not propagated back to peers.  Incoming expected diffs and listener-generated local mutations are now handled separately and correctly. As a result,  stores converge to the same final state

## How did you test this change?

I reproduced the issue with two local synchronizer stores; before the fix they diverged, and after the fix they converged. I added a regression test for this scenario and ran targeted synchronizer tests (Local, BroadcastChannel, Custom). I also ran mergeable-store unit tests to confirm no regressions
